### PR TITLE
fix highlight & highlight-background use same color

### DIFF
--- a/theme.conf
+++ b/theme.conf
@@ -22,9 +22,9 @@ EnableBlur=False
 # 竖排列表时使用所有横向空间高亮
 FullWidthHighlight=True
 # 高亮文字颜色
-HighlightColor=#4285f4
+HighlightColor=#000000
 # 高亮背景颜色
-HighlightBackgroundColor=#4285f4
+HighlightBackgroundColor=#00000000
 
 [InputPanel/Background]
 # 背景图片


### PR DESCRIPTION
Make highlight-backgound to be transparent (use whatever behind it) and make the highlight text to be black.
The Pinyin seems doesn't use that option at all (fcitx bug?), but RIME uses that option.
https://forum.suse.org.cn/t/topic/14466/2